### PR TITLE
Features/public scopes

### DIFF
--- a/issue2pr.rb
+++ b/issue2pr.rb
@@ -36,7 +36,7 @@ class Issue2Pr < Sinatra::Base
     http.use_ssl = true
 
     response = nil
-    res = http.start do |http|
+    http.start do |http|
       req = Net::HTTP::Post.new(uri.request_uri)
       req["Content-type"] = "application/json"
       req["Accept"] = "application/json"

--- a/issue2pr.rb
+++ b/issue2pr.rb
@@ -15,6 +15,7 @@ class Issue2Pr < Sinatra::Base
 
   use OmniAuth::Builder do
     provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET'], scope: "repo"
+    provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET'], scope: "public_repo", path_prefix: "/auth/public"
   end
 
   get '/' do
@@ -124,7 +125,7 @@ __END__
   <div class="row">
     <div class="span12">
       <p>
-        First you've gotta <a href='/auth/github'>sign in with GitHub</a>.
+        First you've gotta <a href='/auth/github'>sign in with GitHub</a> or <a href='/auth/public/github'>just with Public Access</a> .
       </p>
     </div>
   </div>


### PR DESCRIPTION
So I wanted to use issue2pr for transmuting a thing, but I'm always super iffy about granting private scopes to things because I have access to lots of private things.

I added a second auth url that only grants public scopes to issue2pr, thereby making people like myself way less paranoid.
